### PR TITLE
Resolves gh-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -71,18 +71,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-		<version>2.4</version>
+        <version>2.5.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
         </configuration>
       </plugin>
-      
-	  
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-		<version>2.8.1</version>
+        <version>2.8.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -96,13 +95,14 @@
           <overview>${basedir}/src/main/javadoc/overview.html</overview>
           <javadocDirectory>${basedir}/src/main/javadoc</javadocDirectory>
           <reportOutputDirectory>${project.reporting.outputDirectory}/apidocs</reportOutputDirectory>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
       
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-		<version>2.1.2</version>
+        <version>2.1.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -116,7 +116,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-		<version>1.4</version>
+        <version>1.4</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>

--- a/src/test/java/org/javaruntype/type/testtypes/TestTypeFromJavaLangReflectWithSelfBoundedTypeVariables.java
+++ b/src/test/java/org/javaruntype/type/testtypes/TestTypeFromJavaLangReflectWithSelfBoundedTypeVariables.java
@@ -1,0 +1,27 @@
+package org.javaruntype.type.testtypes;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.javaruntype.type.Type;
+import org.javaruntype.type.Types;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestTypeFromJavaLangReflectWithSelfBoundedTypeVariables {
+    public interface X<T extends Comparable<T>> {
+    }
+
+    @Test public void test() throws Exception {
+        Map<String, Type<?>> vars = new HashMap<String, Type<?>>();
+        vars.put("T", Types.forJavaLangReflectType(Integer.class));
+
+        Type<?> t = Types.forJavaLangReflectType(
+            X.class.getTypeParameters()[0],
+            vars);
+
+        assertEquals(Integer.class, t.getRawClass());
+    }
+}


### PR DESCRIPTION
When manufacturing a type token from a j.l.r.Type, any supplied type
variable substitutions are validated against the bounds that constrain
the type variables where they are used. For example, if there is a type
variable T bounded by "extends Serializable", and you supply a substitute
for T that does not implement Serializable, javaruntype will catch this
and report an error.

Type variables can have bounds that refer to the thing being constrained.
For example:

    interface X<T extends Comparable<T>> {
        void foo(T bar);
    }

If I wanted to obtain a type token for X, supplying java.lang.Integer as
the substitute for T, previously javaruntype would recurse forever until
blowing out the call stack.

This change allows previously bounds-validated type variables to skip the
validation check once they've been vetted.