### PR TITLE
Fix bugs with concrete array types in extends declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-		<version>2.4</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>21</source>
+          <target>21</target>
+          <release>21</release>
         </configuration>
       </plugin>
       
@@ -83,7 +84,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-		<version>2.8.1</version>
+		<version>3.6.3</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -103,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-		<version>2.1.2</version>
+		<version>3.3.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/main/java/org/javaruntype/cache/ConcurrentCache.java
+++ b/src/main/java/org/javaruntype/cache/ConcurrentCache.java
@@ -27,7 +27,7 @@ import org.javaruntype.util.Utils;
 
 /**
  * <p>
- * Base synchronized cache for <tt>*Registry</tt> objects.
+ * Base synchronized cache for <code>*Registry</code> objects.
  * </p>
  * <p>
  * <b>Do not</b> use this class directly.

--- a/src/main/java/org/javaruntype/type/ExtendsTypeParameter.java
+++ b/src/main/java/org/javaruntype/type/ExtendsTypeParameter.java
@@ -24,9 +24,9 @@ package org.javaruntype.type;
  * Represents a type parameter which contains an "extends" clause.
  * </p>
  * <p>
- * For example, the type <tt>List&lt;? extends Set&lt;String[]&gt;&gt;</tt>,
- * would have an <tt>ExtendsTypeParameter</tt>
- * containing the <tt>? extends Set&lt;String[]&gt;</tt> parameter.
+ * For example, the type <code>List&lt;? extends Set&lt;String[]&gt;&gt;</code>,
+ * would have an <code>ExtendsTypeParameter</code>
+ * containing the <code>? extends Set&lt;String[]&gt;</code> parameter.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/type/StandardTypeParameter.java
+++ b/src/main/java/org/javaruntype/type/StandardTypeParameter.java
@@ -21,12 +21,12 @@ package org.javaruntype.type;
 
 /**
  * <p>
- * This class represents a type parameter which only contains a <tt>Type</tt>.
+ * This class represents a type parameter which only contains a <code>Type</code>.
  * </p>
  * <p>
- * For example, the type <tt>List&lt;Set&lt;String[]&gt;&gt;</tt>;
- * would have a <tt>StandardTypeParameter</tt>
- * containing the <tt>Set&lt;String[]&gt;</tt> parameter.
+ * For example, the type <code>List&lt;Set&lt;String[]&gt;&gt;</code>;
+ * would have a <code>StandardTypeParameter</code>
+ * containing the <code>Set&lt;String[]&gt;</code> parameter.
  * </p>
  * 
  * 

--- a/src/main/java/org/javaruntype/type/SuperTypeParameter.java
+++ b/src/main/java/org/javaruntype/type/SuperTypeParameter.java
@@ -24,9 +24,9 @@ package org.javaruntype.type;
  * Represents a type parameter which contains a "super" clause.
  * </p>
  * <p>
- * For example, the type <tt>List&lt;? super Set&lt;String[]&gt;&gt;</tt>,
- * would have an <tt>SuperTypeParameter</tt>
- * containing the <tt>? super Set&lt;String[]&gt;</tt> parameter.
+ * For example, the type <code>List&lt;? super Set&lt;String[]&gt;&gt;</code>,
+ * would have an <code>SuperTypeParameter</code>
+ * containing the <code>? super Set&lt;String[]&gt;</code> parameter.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/type/Type.java
+++ b/src/main/java/org/javaruntype/type/Type.java
@@ -35,26 +35,26 @@ import org.javaruntype.util.Utils;
 
 /**
  * <p>
- * Basic class of the type system. A <tt>Type</tt> object representes a Java type including its type parameters (if it has any),
+ * Basic class of the type system. A <code>Type</code> object representes a Java type including its type parameters (if it has any),
  * as specified by the {@link TypeDef} corresponding to the type's component class.
  * </p>
  * <p>
- * Every possible Java type can be represented by a <tt>Type</tt> object. Some examples:
+ * Every possible Java type can be represented by a <code>Type</code> object. Some examples:
  * </p>
  *   <ul>
- *     <li><tt>java.lang.String</tt></li>
- *     <li><tt>java.util.List&lt;java.lang.Integer&gt;</tt></li>
- *     <li><tt>java.util.Comparator&lt;? super java.util.Map&lt;java.lang.String, ? extends java.lang.Number&gt;&gt;</tt></li>
+ *     <li><code>java.lang.String</code></li>
+ *     <li><code>java.util.List&lt;java.lang.Integer&gt;</code></li>
+ *     <li><code>java.util.Comparator&lt;? super java.util.Map&lt;java.lang.String, ? extends java.lang.Number&gt;&gt;</code></li>
  *   </ul>
  *   
  * <p>
- * Objects of this class are never created directly. To obtain a <tt>Type</tt> object,
+ * Objects of this class are never created directly. To obtain a <code>Type</code> object,
  * the diverse methods in the {@link Types} class should be used.
  * </p>
  * <p>
  * Objects of this class are <b>immutable</b>, and thus <b>thread-safe</b>. Also, in order
  * to avoid excessive memory usage, an internal synchronized cache exists which 
- * prevents the same <tt>Type</tt> from being instantiated more than once (so, if two 
+ * prevents the same <code>Type</code> from being instantiated more than once (so, if two 
  * Type objects are equal, this will mean that they are the same object).
  * </p>
  * 

--- a/src/main/java/org/javaruntype/type/TypeParameter.java
+++ b/src/main/java/org/javaruntype/type/TypeParameter.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  * Abstract class that represents a type parameter in a {@link Type} object.
  * </p>
  * <p>
- * <tt>TypeParameter&lt;?&gt;</tt> objects, depending on its specific subclass, can represent:
+ * <code>TypeParameter&lt;?&gt;</code> objects, depending on its specific subclass, can represent:
  * </p>
  * <ul>
  *   <li>List&lt;<b>?</b>&gt; ({@link WildcardTypeParameter})
@@ -50,7 +50,7 @@ public abstract class TypeParameter<T> implements Serializable {
 	/**
 	 * <p>
 	 * Returns the type contained in the parameter. It will raise an exception
-	 * for wildcard type parameters (<tt>?</tt>).
+	 * for wildcard type parameters (<code>?</code>).
 	 * </p>
 	 * 
 	 * @return the type contained in the parameter.

--- a/src/main/java/org/javaruntype/type/TypeUtil.java
+++ b/src/main/java/org/javaruntype/type/TypeUtil.java
@@ -671,13 +671,13 @@ final class TypeUtil {
         final java.lang.reflect.Type superclassTypeDeclaration = 
             componentClass.getGenericSuperclass();
         if (superclassTypeDeclaration != null) {
-            final Type<?> superclassType = resolveExtendedTypeByDeclaration(type, superclassTypeDeclaration);
+            final Type<?> superclassType = resolveExtendedTypeByDeclaration(type, superclassTypeDeclaration, 0);
             equivalenceSet.add(superclassType);
             equivalenceSet.addAll(typeRegistry.getExtendedTypes(superclassType));
         }
         
         for (java.lang.reflect.Type interfaceTypeDeclaration : componentClass.getGenericInterfaces()) {
-            final Type<?> interfaceType = resolveExtendedTypeByDeclaration(type, interfaceTypeDeclaration);
+            final Type<?> interfaceType = resolveExtendedTypeByDeclaration(type, interfaceTypeDeclaration, 0);
             equivalenceSet.add(interfaceType);
             equivalenceSet.addAll(typeRegistry.getExtendedTypes(interfaceType));
         }
@@ -688,7 +688,8 @@ final class TypeUtil {
     
     
     private static Type<?> resolveExtendedTypeByDeclaration(
-            final Type<?> originalType, final java.lang.reflect.Type typeDeclaration) {
+            final Type<?> originalType, final java.lang.reflect.Type typeDeclaration,
+            final int arrayDimensions) {
 
         final Map<String,TypeParameter<?>> typeParametersMap = 
             new HashMap<String, TypeParameter<?>>();
@@ -768,7 +769,7 @@ final class TypeUtil {
 
         final TypeRegistry typeRegistry = TypeRegistry.getInstance();
         return typeRegistry.getTypeWithoutValidation(
-                componentClass, typeParameters, originalType.getArrayDimensions());
+                componentClass, typeParameters, arrayDimensions);
         
     }
     
@@ -843,7 +844,14 @@ final class TypeUtil {
             return resolveEquivalentTypeParameterByDeclaration(
                     originalType, genericArrayType.getGenericComponentType(), 
                     (arrayDimensions + 1));
-            
+           
+        } else if (typeDeclaration instanceof Class 
+			&& ((Class<?>) typeDeclaration).isArray()) {
+            final Class<?> concreteArrayType = (Class<?>) typeDeclaration;
+
+            return resolveEquivalentTypeParameterByDeclaration(
+		    originalType, concreteArrayType.getComponentType(),
+                    (arrayDimensions + 1)); 
         } else {
 
             /*
@@ -865,7 +873,7 @@ final class TypeUtil {
             
             // Create the appropiate type recursively
             final Type<?> parameterizedTypeDeclarationArgumentType = 
-                resolveExtendedTypeByDeclaration(baseType, typeDeclaration);
+                resolveExtendedTypeByDeclaration(baseType, typeDeclaration, arrayDimensions);
 
             return new StandardTypeParameter(parameterizedTypeDeclarationArgumentType);
             

--- a/src/main/java/org/javaruntype/type/WildcardTypeParameter.java
+++ b/src/main/java/org/javaruntype/type/WildcardTypeParameter.java
@@ -26,9 +26,9 @@ import java.io.ObjectStreamException;
  * Represents a type parameter which only contains an unknown (a wildcard).
  * </p>
  * <p>
- * For example, the type <tt>List&lt;?;&gt;</tt>,
- * would have a <tt>UnknownTypeParameter</tt>
- * containing the <tt>?</tt> parameter.
+ * For example, the type <code>List&lt;?;&gt;</code>,
+ * would have a <code>UnknownTypeParameter</code>
+ * containing the <code>?</code> parameter.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/typedef/BoundedTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/BoundedTypeDefVariable.java
@@ -25,10 +25,10 @@ import org.javaruntype.util.Utils;
 /**
  * <p>
  * Represents a type definition variable which, besides a name, specifies a series of
- * <i>bounds</i> with an <tt>extends</tt> expression.
+ * <i>bounds</i> with an <code>extends</code> expression.
  * </p>
  * <p>
- * A variable can specify several bounds with "<tt>&amp;</tt>": <tt>X extends [bound]&amp;[bound]&amp;[bound]...</tt>.
+ * A variable can specify several bounds with "<code>&amp;</code>": <code>X extends [bound]&amp;[bound]&amp;[bound]...</code>.
  * </p>
  * <p>
  * Bounds for a bounded type definition variable are represented by objects of type

--- a/src/main/java/org/javaruntype/typedef/InnerClassTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerClassTypeDefVariable.java
@@ -24,7 +24,7 @@ package org.javaruntype.typedef;
  * Represents an inner type definition variable which specifies a class.
  * </p>
  * <p>
- * For example: <tt>X extends <b>String</b></tt>.
+ * For example: <code>X extends <b>String</b></code>.
  * </p>
  * 
  * 

--- a/src/main/java/org/javaruntype/typedef/InnerNamedTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerNamedTypeDefVariable.java
@@ -24,7 +24,7 @@ package org.javaruntype.typedef;
  * Represents an inner type definition variable containing a variable name.
  * </p>
  * <p>
- * For example: <tt>X extends <b>T</b></tt>.
+ * For example: <code>X extends <b>T</b></code>.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/typedef/InnerParameterizedTypeTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerParameterizedTypeTypeDefVariable.java
@@ -28,7 +28,7 @@ import org.javaruntype.util.Utils;
  * Represents an inner type definition variable containing a parameterized type.
  * </p>
  * <p>
- * For example: <tt>X extends <b>List&lt;Integer&gt;</b></tt>.
+ * For example: <code>X extends <b>List&lt;Integer&gt;</b></code>.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/typedef/InnerTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerTypeDefVariable.java
@@ -23,17 +23,17 @@ import java.io.Serializable;
 
 /**
  * <p>
- * Specifies an inner type definition variable which can be both a bound for a <tt>BoundTypeDefVariable</tt> or
- * a type variable for another <tt>InnerTypeDefVariable</tt>.
+ * Specifies an inner type definition variable which can be both a bound for a <code>BoundTypeDefVariable</code> or
+ * a type variable for another <code>InnerTypeDefVariable</code>.
  * </p>
  * <p>
  * Inner type definition variables can take several shapes:
  * </p>
  * <ul>
- *   <li><tt>X extends <b>String</b></tt>: {@link InnerClassTypeDefVariable}</li>
- *   <li><tt>X extends <b>T</b></tt>: {@link InnerNamedTypeDefVariable}</li>
- *   <li><tt>X extends <b>List&lt;Integer&gt;</b></tt>: {@link InnerParameterizedTypeTypeDefVariable}</li>
- *   <li><tt>X extends List&lt;<b>? extends Integer</b>&gt;</tt>: {@link InnerWildcardTypeDefVariable}</li>
+ *   <li><code>X extends <b>String</b></code>: {@link InnerClassTypeDefVariable}</li>
+ *   <li><code>X extends <b>T</b></code>: {@link InnerNamedTypeDefVariable}</li>
+ *   <li><code>X extends <b>List&lt;Integer&gt;</b></code>: {@link InnerParameterizedTypeTypeDefVariable}</li>
+ *   <li><code>X extends List&lt;<b>? extends Integer</b>&gt;</code>: {@link InnerWildcardTypeDefVariable}</li>
  * </ul>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/typedef/InnerWildcardTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerWildcardTypeDefVariable.java
@@ -27,7 +27,7 @@ import org.javaruntype.util.Utils;
  * Represents an inner type definition variable containing a wildcard or bounded wildcard type.
  * </p>
  * <p>
- * For example: <tt>X extends List&lt;<b>? extends Integer</b>&gt;</tt>.
+ * For example: <code>X extends List&lt;<b>? extends Integer</b>&gt;</code>.
  * </p>
  * 
  * @since 1.0
@@ -79,7 +79,7 @@ public final class InnerWildcardTypeDefVariable implements InnerTypeDefVariable 
 
     /**
      * <p>
-     * Returns whether the variable establishes an upper bound (with an <tt>extends</tt> clause).
+     * Returns whether the variable establishes an upper bound (with an <code>extends</code> clause).
      * </p>
      * 
      * @return whether the variable establishes an upper bound
@@ -91,7 +91,7 @@ public final class InnerWildcardTypeDefVariable implements InnerTypeDefVariable 
     
     /**
      * <p>
-     * Returns the variable upper bound (defined with an <tt>extends</tt> clause), if any.
+     * Returns the variable upper bound (defined with an <code>extends</code> clause), if any.
      * </p>
      * 
      * @return the upper bound
@@ -103,7 +103,7 @@ public final class InnerWildcardTypeDefVariable implements InnerTypeDefVariable 
     
     /**
      * <p>
-     * Returns whether the variable establishes a lower bound (with a <tt>super</tt> clause).
+     * Returns whether the variable establishes a lower bound (with a <code>super</code> clause).
      * </p>
      * 
      * @return whether the variable establishes a lower bound
@@ -115,7 +115,7 @@ public final class InnerWildcardTypeDefVariable implements InnerTypeDefVariable 
     
     /**
      * <p>
-     * Returns the variable upper bound (defined with an <tt>extends</tt> clause), if any.
+     * Returns the variable upper bound (defined with an <code>extends</code> clause), if any.
      * </p>
      * 
      * @return the upper bound

--- a/src/main/java/org/javaruntype/typedef/InnerWildcardTypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/InnerWildcardTypeDefVariable.java
@@ -68,7 +68,7 @@ public final class InnerWildcardTypeDefVariable implements InnerTypeDefVariable 
             final InnerTypeDefVariable lowerBound) {
         super();
         // Cannot have lower and upper bound at a time
-        Utils.validateIsTrue(!(upperBound != null) && (lowerBound != null));
+        Utils.validateIsTrue(!((upperBound != null) && (lowerBound != null)));
         this.upperBound = upperBound;
         this.lowerBound = lowerBound;
         this.stringRepresentation = 

--- a/src/main/java/org/javaruntype/typedef/TypeDef.java
+++ b/src/main/java/org/javaruntype/typedef/TypeDef.java
@@ -34,30 +34,30 @@ import org.javaruntype.util.Utils;
  * Examples of type definitions are:
  * </p>
  * <ul>
- *   <li><tt>app.pack.ClassOne</tt></li>
- *   <li><tt>app.pack.ClassTwo&lt;E&gt;</tt></li>
- *   <li><tt>app.pack.ClassThree&lt;E, T&gt;</tt></li>
- *   <li><tt>app.pack.ClassFour&lt;E, T extends E&gt;</tt></li>
- *   <li><tt>app.pack.ClassFive&lt;E, T extends java.io.Serializable&gt;</tt></li>
- *   <li><tt>app.pack.ClassSix&lt;E, T extends E &amp; java.io.Serializable&gt;</tt></li>
- *   <li><tt>app.pack.ClassSeven&lt;E, T, X extends E &amp; java.util.Collection&lt;T&gt;&gt;</tt></li>
- *   <li><tt>app.pack.ClassEight&lt;E, T, X extends E &amp; java.util.Collection&lt;? extends T&gt;&gt;</tt></li>
+ *   <li><code>app.pack.ClassOne</code></li>
+ *   <li><code>app.pack.ClassTwo&lt;E&gt;</code></li>
+ *   <li><code>app.pack.ClassThree&lt;E, T&gt;</code></li>
+ *   <li><code>app.pack.ClassFour&lt;E, T extends E&gt;</code></li>
+ *   <li><code>app.pack.ClassFive&lt;E, T extends java.io.Serializable&gt;</code></li>
+ *   <li><code>app.pack.ClassSix&lt;E, T extends E &amp; java.io.Serializable&gt;</code></li>
+ *   <li><code>app.pack.ClassSeven&lt;E, T, X extends E &amp; java.util.Collection&lt;T&gt;&gt;</code></li>
+ *   <li><code>app.pack.ClassEight&lt;E, T, X extends E &amp; java.util.Collection&lt;? extends T&gt;&gt;</code></li>
  *   <li>etc...</li>
  * </ul>
  * <p>
  * These type definitions serve as a template for creating <b>types</b> ({@link org.javaruntype.type.Type} class), which
- * resolve all type variables present in the type definition (for example, for a <tt>TypeDef</tt>
- * object <tt>java.util.Collection&lt;E&gt;</tt> we can get a <tt>Type</tt> object
- * <tt>java.util.Collection&lt;java.lang.String&gt;</tt>
+ * resolve all type variables present in the type definition (for example, for a <code>TypeDef</code>
+ * object <code>java.util.Collection&lt;E&gt;</code> we can get a <code>Type</code> object
+ * <code>java.util.Collection&lt;java.lang.String&gt;</code>
  * </p>
  * <p>
- * Objects of this class are never created directly. To obtain a <tt>TypeDef</tt> object,
+ * Objects of this class are never created directly. To obtain a <code>TypeDef</code> object,
  * the diverse methods in the {@link TypeDefs} class should be used.
  * </p>
  * <p>
  * Objects of this class are <b>immutable</b>, and thus <b>thread-safe</b>. Also, in order
  * to avoid excessive memory usage, an internal synchronized cache exists which 
- * prevents the same <tt>TypeDef</tt> from being instantiated more than once (so, if two 
+ * prevents the same <code>TypeDef</code> from being instantiated more than once (so, if two 
  * TypeDef objects are equal, this will mean that they are the same object).
  * </p>
  * 
@@ -115,8 +115,8 @@ public final class TypeDef implements Serializable {
     /**
      * 
      * Returns the component class of the type definition. For example, if the type definition
-     * is <tt>java.util.Collection&lt;E&gt;</tt>, this method will return
-     * <tt>java.lang.Class&lt;java.util.Collection&gt;</tt>
+     * is <code>java.util.Collection&lt;E&gt;</code>, this method will return
+     * <code>java.lang.Class&lt;java.util.Collection&gt;</code>
      * 
      * @return the component class.
      */

--- a/src/main/java/org/javaruntype/typedef/TypeDefUtil.java
+++ b/src/main/java/org/javaruntype/typedef/TypeDefUtil.java
@@ -114,14 +114,14 @@ final class TypeDefUtil {
         } else if (typeDeclaration instanceof WildcardType) {
 
             final WildcardType wildcardType = (WildcardType) typeDeclaration;
-            if (!Utils.isArrayEqual(OBJECT_BOUNDS, wildcardType.getUpperBounds())) {
+            if (wildcardType.getUpperBounds().length > 0 && !Utils.isArrayEqual(OBJECT_BOUNDS, wildcardType.getUpperBounds())) {
                 
                 final InnerTypeDefVariable upperBound = 
                         getInnerTypeDefDeclaration(
                                 wildcardType.getUpperBounds()[0], 0);
                 return new InnerWildcardTypeDefVariable(upperBound, null);
                 
-            } else if (!Utils.isArrayEqual(OBJECT_BOUNDS, wildcardType.getLowerBounds())) {
+            } else if (wildcardType.getLowerBounds().length > 0 && !Utils.isArrayEqual(OBJECT_BOUNDS, wildcardType.getLowerBounds())) {
                 
                 final InnerTypeDefVariable lowerBound = 
                         getInnerTypeDefDeclaration(

--- a/src/main/java/org/javaruntype/typedef/TypeDefVariable.java
+++ b/src/main/java/org/javaruntype/typedef/TypeDefVariable.java
@@ -28,33 +28,33 @@ import java.io.Serializable;
  * of them represented by one of this interface's implementing classes):
  * </p>
  * <ul>
- *   <li>Named (<tt>NamedTypeDefVariable</tt>): <tt>E</tt></li>
- *   <li>Bounded (<tt>BoundedTypeDefVariable</tt>): <tt>E extends T</tt></li>
+ *   <li>Named (<code>NamedTypeDefVariable</code>): <code>E</code></li>
+ *   <li>Bounded (<code>BoundedTypeDefVariable</code>): <code>E extends T</code></li>
  * </ul>
  * <p>
  * Some examples:
  * </p>
  * <ul>
- *   <li><tt>app.pack.ClassOne</tt> contains no <tt>TypeDefVariable</tt>s.</li>
- *   <li><tt>app.pack.ClassThree&lt;E, T&gt;</tt> contains two <tt>TypeDefVariable</tt>s:
+ *   <li><code>app.pack.ClassOne</code> contains no <code>TypeDefVariable</code>s.</li>
+ *   <li><code>app.pack.ClassThree&lt;E, T&gt;</code> contains two <code>TypeDefVariable</code>s:
  *       <ul>
- *         <li><tt>E</tt> (named)</li>
- *         <li><tt>T</tt> (named)</li>
+ *         <li><code>E</code> (named)</li>
+ *         <li><code>T</code> (named)</li>
  *       </ul> 
  *   </li>
- *   <li><tt>app.pack.ClassEight&lt;E, T, X extends E &amp; java.util.Collection&lt;? extends T&gt;&gt;</tt> contains three <tt>TypeDefVariable</tt>s:
+ *   <li><code>app.pack.ClassEight&lt;E, T, X extends E &amp; java.util.Collection&lt;? extends T&gt;&gt;</code> contains three <code>TypeDefVariable</code>s:
  *       <ul>
- *         <li><tt>E</tt> (named)</li>
- *         <li><tt>T</tt> (named)</li>
- *         <li><tt>X extends E &amp; java.util.Collection&lt;? extends T&gt;</tt> (bounded)</li>
+ *         <li><code>E</code> (named)</li>
+ *         <li><code>T</code> (named)</li>
+ *         <li><code>X extends E &amp; java.util.Collection&lt;? extends T&gt;</code> (bounded)</li>
  *       </ul> 
  *   </li>
  * </ul>
  * 
  * <p>
- * As can be seen above, <i>every</i> type definition variable has, at least, a <b>name</b>: <tt>E</tt> ,<tt>T</tt> and <tt>X</tt>
+ * As can be seen above, <i>every</i> type definition variable has, at least, a <b>name</b>: <code>E</code> ,<code>T</code> and <code>X</code>
  * in the above examples. Also, it can be noted that bounded variables can create relations among variables, like in 
- * <tt>X extends E</tt>.
+ * <code>X extends E</code>.
  * </p>
  * 
  * @since 1.0

--- a/src/main/java/org/javaruntype/typedef/TypeDefs.java
+++ b/src/main/java/org/javaruntype/typedef/TypeDefs.java
@@ -24,7 +24,7 @@ import org.javaruntype.util.Utils;
 /**
  * <p>
  * This is the central and basic factory class for {@link TypeDef} objects. Every
- * <tt>TypeDef</tt> object should be exclusively obtained by means of this class's methods.
+ * <code>TypeDef</code> object should be exclusively obtained by means of this class's methods.
  * </p>
  * 
  * @since 1.0
@@ -37,7 +37,7 @@ public final class TypeDefs {
 
     /**
      * <p>
-     * Retrieves the <tt>TypeDef</tt> object corresponding with the given class.
+     * Retrieves the <code>TypeDef</code> object corresponding with the given class.
      * </p>
      * 
      * @param typeClass the class which TypeDef must be obtained.

--- a/src/test/java/org/javaruntype/type/TestExtendParametrizedByConcreteArray.java
+++ b/src/test/java/org/javaruntype/type/TestExtendParametrizedByConcreteArray.java
@@ -1,0 +1,38 @@
+package org.javaruntype.type;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.javaruntype.type.testtypes.TType3;
+
+import junit.framework.TestCase;
+
+public class TestExtendParametrizedByConcreteArray extends TestCase {
+
+    private abstract static class A implements Collection<List<Integer[]>[][]> {
+
+    }
+
+    public void test() {
+        Type<TType3<Object, Integer, Integer>> type3 = Types.forClass(TType3.class,
+                TypeParameters.forType(Types.OBJECT),
+                TypeParameters.forType(Types.INTEGER),
+                TypeParameters.forType(Types.INTEGER));
+
+        assertTrue(type3.getAllTypesAssignableFromThis()
+                .contains(Types.forClass(Map.class,
+                        TypeParameters.forType(Types.ARRAY_OF_INTEGER),
+                        TypeParameters.forType(Types.INTEGER))));
+    }
+
+    public void testArrayParametrized() {
+        Type<A> t = Types.forClass(A.class);
+
+        assertTrue(t.getAllTypesAssignableFromThis().contains(Types.forClass(Collection.class,
+                TypeParameters.forType(Types.arrayOf(
+                        Types.arrayOf(Types.forClass(List.class, TypeParameters.forType(Types.ARRAY_OF_INTEGER))))))));
+    }
+
+}
+


### PR DESCRIPTION
Fixed 2 bugs occuring when using concrete array types in extends declarations :

Bug 1 => `class A extends List<Integer[]>`
This type was correctly parsed but any call to `getAllTypesAssignableFromThis` would fail by trying to get a TypeDef of the array class Integer[]

Bug 2 => `class A extends List<List<Integer>[]>`
This type was not parsed correctly (result was  `List<List<Integer>>`)

This PR fixes both bugs and adds (minor) tests to show the issues.
